### PR TITLE
Adding cross-building JVM-JS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,66 +1,92 @@
 import sbt.Keys.scalaVersion
 import sbt._
+import sbtcrossproject.{CrossType, crossProject}
 
 val monocleVersion = "1.4.0"
 
-lazy val xenomorph = project.in(file("."))
-  .dependsOn(core, argonaut, scalacheck, scodec)
-  .aggregate(core, argonaut, scalacheck, scodec)
+lazy val xenomorph = project
+  .in(file("."))
+  .aggregate(
+    coreJVM, coreJS,
+    scalacheckJVM, scalacheckJS,
+    argonautJVM, argonautJS,
+    scodecJVM
+  )
   .settings(commonSettings)
   .settings(
-    name := "xenomorph"
+    name := "xenomorph",
+    publish := {},
+    publishLocal := {}
   )
 
-lazy val core = project.in(file("modules/core"))
+lazy val core = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/core"))
   .settings(commonSettings)
   .settings(
     name := "xenomorph-core",
     libraryDependencies ++= Seq(
-      "org.scalaz"                    %% "scalaz-core"     % "7.2.14",
-      "com.chuusai"                   %% "shapeless"       % "2.3.2",
-      "com.github.julien-truffaut"    %% "monocle-core"    % monocleVersion,
+      "org.scalaz"                    %%% "scalaz-core"     % "7.2.18",
+      "com.chuusai"                   %%% "shapeless"       % "2.3.2",
+      "com.github.julien-truffaut"    %%% "monocle-core"    % monocleVersion,
       // test dependencies
-      "com.github.julien-truffaut"  %%  "monocle-generic"  % monocleVersion % "test",
-      "com.github.julien-truffaut"  %%  "monocle-macro"    % monocleVersion % "test",
-      "com.github.julien-truffaut"  %%  "monocle-state"    % monocleVersion % "test",
-      "com.github.julien-truffaut"  %%  "monocle-refined"  % monocleVersion % "test",
-      "com.github.julien-truffaut"  %%  "monocle-law"      % monocleVersion % "test",
-      "joda-time"                   % "joda-time"          % "2.9.4"        % "test",
-      "org.specs2"                  %% "specs2-core"       % "3.9.4"        % "test",
-      "org.specs2"                  %% "specs2-scalacheck" % "3.9.4"        % "test"
+      "com.github.julien-truffaut"  %%%  "monocle-generic"  % monocleVersion % "test",
+      "com.github.julien-truffaut"  %%%  "monocle-macro"    % monocleVersion % "test",
+      "com.github.julien-truffaut"  %%%  "monocle-state"    % monocleVersion % "test",
+      "com.github.julien-truffaut"  %%%  "monocle-refined"  % monocleVersion % "test",
+      "com.github.julien-truffaut"  %%%  "monocle-law"      % monocleVersion % "test",
+      "org.scalatest"               %%% "scalatest"         % "3.0.4"        % "test",
+      "org.scalacheck"              %%% "scalacheck"        % "1.13.4"       % "test"
     )
   )
 
-lazy val argonaut = project.in(file("modules/argonaut"))
+lazy val coreJVM = core.jvm
+lazy val coreJS = core.js
+
+lazy val argonaut = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/argonaut"))
   .dependsOn(core % "compile->compile;test->test", scalacheck % "test->test")
   .settings(commonSettings)
   .settings(
     name := "xenomorph-argonaut",
     libraryDependencies ++= Seq(
-      "io.argonaut" %% "argonaut" % "6.2"
+      "io.argonaut" %%% "argonaut" % "6.2.1"
     )
   )
 
-lazy val scodec = project.in(file("modules/scodec"))
+lazy val argonautJVM = argonaut.jvm
+lazy val argonautJS = argonaut.js
+
+lazy val scodec = crossProject(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/scodec"))
   .dependsOn(core % "compile->compile;test->test", scalacheck % "test->test")
   .settings(commonSettings)
   .settings(
     name := "xenomorph-scodec",
     libraryDependencies ++= Seq(
-      "org.scodec" %% "scodec-core" % "1.10.3",
-      "org.scodec" %% "scodec-scalaz" % "1.4.1a"
+      "org.scodec" %%% "scodec-core" % "1.10.3",
+      "org.scodec" %%% "scodec-scalaz" % "1.4.1a"
     )
   )
 
-lazy val scalacheck = project.in(file("modules/scalacheck"))
+lazy val scodecJVM = scodec.jvm
+
+lazy val scalacheck = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/scalacheck"))
   .dependsOn(core % "compile->compile;test->test")
   .settings(commonSettings)
   .settings(
     name := "xenomorph-scalacheck",
     libraryDependencies ++= Seq(
-      "org.scalacheck" %% "scalacheck"  % "1.13.5"
+      "org.scalacheck" %%% "scalacheck"  % "1.13.5"
     )
   )
+
+lazy val scalacheckJVM = scalacheck.jvm
+lazy val scalacheckJS = scalacheck.js
 
 
 lazy val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,11 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.scalacheck"              %%% "scalacheck"        % "1.13.4"       % "test"
     )
   )
+  .jsSettings(
+    libraryDependencies ++= Seq(
+      "org.scala-js" %%% "scalajs-java-time" % "0.2.3" % "test"
+    )
+  )
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js

--- a/modules/argonaut/src/test/scala/xenomorph.argonaut/ArgonautSpec.scala
+++ b/modules/argonaut/src/test/scala/xenomorph.argonaut/ArgonautSpec.scala
@@ -15,16 +15,11 @@
 package xenomorph.argonaut
 
 import org.scalacheck._
-import org.specs2._
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers
 import xenomorph.samples._
 
-class ArgonautSpec extends Specification with org.specs2.ScalaCheck {
-  def is = s2"""
-  Serialization of values to JSON should
-    serialize a value to JSON $toJson
-    read a value from JSON $fromJson
-    round-trip values produced by a generator $gen
-  """
+class ArgonautSpec extends FunSuite with Checkers {
 
   import xenomorph.scalacheck.ToGen._
   import xenomorph.scalacheck.Implicits._
@@ -32,21 +27,23 @@ class ArgonautSpec extends Specification with org.specs2.ScalaCheck {
   import xenomorph.argonaut.ToJson._
   import xenomorph.argonaut.FromJson._
 
-  def toJson = {
+  test("A value should serialise to JSON") {
     val result = Person.schema.toJson(person)
-    result.toString must_== """{"roles":[{"administrator":{"subordinateCount":0,"department":"windmill-tilting"}}],"birthDate":20147028000,"name":"Kris Nuttycombe"}"""
+    assert(result.toString == """{"roles":[{"administrator":{"subordinateCount":0,"department":"windmill-tilting"}}],"birthDate":20147028000,"name":"Kris Nuttycombe"}""")
   }
 
-  def fromJson = {
+  test("A value should be deserialised from JSON"){
     val result = Person.schema.toJson(person)
-    Person.schema.fromJson(result).toOption must_== Some(person)
+    assert(Person.schema.fromJson(result).toOption == Some(person))
   }
 
-  def gen = {
+
+  test("Serialization should round-trip values produced by a generator"){
     implicit val arbPerson : Arbitrary[Person] = Arbitrary(Person.schema.toGen)
-    prop(
+    check{
       (p: Person) =>
-        Person.schema.fromJson(Person.schema.toJson(p)).toOption must_== Some(p)
-    )
+        Person.schema.fromJson(Person.schema.toJson(p)).toOption == Some(p)
+    }
   }
+
 }

--- a/modules/core/src/test/scala/xenomorph/Samples.scala
+++ b/modules/core/src/test/scala/xenomorph/Samples.scala
@@ -1,31 +1,28 @@
 package xenomorph
 
-import scalaz.syntax.apply._
-
-import monocle.Iso
 import monocle.macros._
-
-import org.joda.time.Instant
-
+import shapeless.HNil
 import xenomorph.Schema._
 import xenomorph.json.JType._
 
-import shapeless.HNil
+import scalaz.syntax.apply._
 
 package samples {
+
+
   @Lenses case class Person(
     name: String,
-    birthDate: Instant,
+    birthDate: Long,
     roles: Vector[Role]
   )
 
   object Person {
+
     val schema: Schema[JSchema, Person] = rec(
       ^^(
         required("name", jStr, Person.name.asGetter),
         required(
-          "birthDate", jLong.composeIso(Iso(new Instant(_:Long))((_:Instant).getMillis)),
-          Person.birthDate.asGetter
+          "birthDate", jLong, Person.birthDate.asGetter
         ),
         required("roles", jArray(Role.schema), Person.roles.asGetter)
       )(Person.apply)
@@ -67,7 +64,7 @@ package samples {
 package object samples {
   val person = Person(
     "Kris Nuttycombe",
-    new Instant(20147028000l),
+    20147028000l,
     Vector(Administrator("windmill-tilting", 0))
   )
 }

--- a/modules/core/src/test/scala/xenomorph/Samples.scala
+++ b/modules/core/src/test/scala/xenomorph/Samples.scala
@@ -1,5 +1,8 @@
 package xenomorph
 
+import java.time.Instant
+
+import monocle.Iso
 import monocle.macros._
 import shapeless.HNil
 import xenomorph.Schema._
@@ -9,10 +12,9 @@ import scalaz.syntax.apply._
 
 package samples {
 
-
   @Lenses case class Person(
     name: String,
-    birthDate: Long,
+    birthDate: Instant,
     roles: Vector[Role]
   )
 
@@ -22,7 +24,8 @@ package samples {
       ^^(
         required("name", jStr, Person.name.asGetter),
         required(
-          "birthDate", jLong, Person.birthDate.asGetter
+          "birthDate", jLong.composeIso(Iso(Instant.ofEpochMilli(_:Long))((_ : Instant).toEpochMilli)),
+          Person.birthDate.asGetter
         ),
         required("roles", jArray(Role.schema), Person.roles.asGetter)
       )(Person.apply)
@@ -64,7 +67,7 @@ package samples {
 package object samples {
   val person = Person(
     "Kris Nuttycombe",
-    20147028000l,
+    Instant.ofEpochMilli(20147028000l),
     Vector(Administrator("windmill-tilting", 0))
   )
 }

--- a/modules/scalacheck/src/test/scala/xenomorph/scalacheck/Implicits.scala
+++ b/modules/scalacheck/src/test/scala/xenomorph/scalacheck/Implicits.scala
@@ -19,7 +19,7 @@ object Implicits {
         case JByteT()   => arbitrary[Byte]
         case JShortT()  => arbitrary[Short]
         case JIntT()    => arbitrary[Int]
-        case JLongT()   => arbitrary[Long]
+        case JLongT()   => Gen.chooseNum(Long.MinValue + 808L, Long.MaxValue) // Magic number to circumvent Instant#toEpochMillis throwing exceptions
         case JFloatT()  => arbitrary[Float]
         case JDoubleT() => arbitrary[Double]
         case JCharT()   => arbitrary[Char]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.21")
+addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "0.3.0")  
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"         % "0.3.6")


### PR DESCRIPTION
I wanted to cross-compile to JS before adding CI.

* Added crossproject plugin
* Changed structure of projects to allow for cross-compilation when possible.
* Replaced Specs2 by Scalatest, which appears to behave better at runtime in a JS environment. 
* Removed Instant fom Person model, as it didn't compile in ScalaJS. I'll replace it with some alternative cross-compiled type, or will add JVM specific models 