### PR TITLE
Added cross-compilation to scodec module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val xenomorph = project
     coreJVM, coreJS,
     scalacheckJVM, scalacheckJS,
     argonautJVM, argonautJS,
-    scodecJVM
+    scodecJVM, scodecJS
   )
   .settings(commonSettings)
   .settings(
@@ -63,7 +63,7 @@ lazy val argonaut = crossProject(JVMPlatform, JSPlatform)
 lazy val argonautJVM = argonaut.jvm
 lazy val argonautJS = argonaut.js
 
-lazy val scodec = crossProject(JVMPlatform)
+lazy val scodec = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("modules/scodec"))
   .dependsOn(core % "compile->compile;test->test", scalacheck % "test->test")
@@ -71,12 +71,12 @@ lazy val scodec = crossProject(JVMPlatform)
   .settings(
     name := "xenomorph-scodec",
     libraryDependencies ++= Seq(
-      "org.scodec" %%% "scodec-core" % "1.10.3",
-      "org.scodec" %%% "scodec-scalaz" % "1.4.1a"
+      "org.scodec" %%% "scodec-core" % "1.10.3"
     )
   )
 
 lazy val scodecJVM = scodec.jvm
+lazy val scodecJS = scodec.js
 
 lazy val scalacheck = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)

--- a/modules/scodec/src/main/scala/xenomorph/scodec/LowPriorityScalazInstances.scala
+++ b/modules/scodec/src/main/scala/xenomorph/scodec/LowPriorityScalazInstances.scala
@@ -1,0 +1,25 @@
+package xenomorph.scodec
+
+import scodec.{Attempt, Decoder}
+
+import scalaz.{Applicative, Monad, Traverse}
+
+trait LowPriorityScalazInstances {
+
+  implicit val AttemptInstance: Monad[Attempt] with Traverse[Attempt] = new Monad[Attempt] with Traverse[Attempt]{
+    def point[A](a: => A) = Attempt.successful(a)
+    def bind[A, B](fa: Attempt[A])(f: A => Attempt[B]) = fa.flatMap(f)
+
+    def traverseImpl[G[_], A, B](fa: Attempt[A])(f: A => G[B])(implicit G: Applicative[G]): G[Attempt[B]] =
+      fa match {
+        case Attempt.Successful(value)  => G.map(f(value))(Attempt.Successful(_))
+        case failure@Attempt.Failure(_) => G.point(failure)
+      }
+  }
+
+  implicit val DecoderInstance : Monad[Decoder] = new Monad[Decoder]{
+    def point[A](a: => A) = Decoder.point(a)
+    def bind[A, B](fa: Decoder[A])(f: A => Decoder[B]) = fa.flatMap(f)
+  }
+
+}

--- a/modules/scodec/src/main/scala/xenomorph/scodec/ToScodec.scala
+++ b/modules/scodec/src/main/scala/xenomorph/scodec/ToScodec.scala
@@ -17,7 +17,6 @@ package xenomorph.scodec
 import scodec._
 import scodec.bits._
 import scodec.codecs.implicits._
-import scodec.interop.scalaz._
 
 import scalaz.~>
 import scalaz.StateT

--- a/modules/scodec/src/main/scala/xenomorph/scodec/package.scala
+++ b/modules/scodec/src/main/scala/xenomorph/scodec/package.scala
@@ -1,0 +1,5 @@
+package xenomorph
+
+package object scodec extends LowPriorityScalazInstances {
+
+}


### PR DESCRIPTION
Following previous discussion : https://github.com/nuttycom/xenomorph/pull/4#discussion_r163186792

* Removed scodec<->scalaz interop library dependency 

* Implemented orphan scalaz instances required for the scodec ToEncoder/ToDecoder functions to compile

* Added JSPlatform to the scodec module